### PR TITLE
feat: dws-4693 added available region response

### DIFF
--- a/nodeshift/provider/client/client.go
+++ b/nodeshift/provider/client/client.go
@@ -26,6 +26,8 @@ const (
 	VPCEndpoint = "/api/terraform/vpc"
 
 	GPUEndpoint = "/api/terraform/gpu"
+
+	RegionsEndpoint = "/api/terraform/deployment/all-countries"
 )
 
 type NodeshiftClient struct {

--- a/nodeshift/provider/client/client_mock.go
+++ b/nodeshift/provider/client/client_mock.go
@@ -91,3 +91,7 @@ func (m *mockedClient) UpdateBucket(ctx context.Context, bucket *S3BucketConfig)
 func (m *mockedClient) DeleteBucket(ctx context.Context, key string) error {
 	return nil
 }
+
+func (m *mockedClient) ListRegions(ctx context.Context) ([]string, error) {
+	return []string{}, nil
+}

--- a/nodeshift/provider/client/deployment.go
+++ b/nodeshift/provider/client/deployment.go
@@ -124,3 +124,17 @@ pollingCycle:
 
 	return deploymentResponse, nil
 }
+
+func (c *NodeshiftClient) ListRegions(ctx context.Context) ([]string, error) {
+	b, err := c.DoSignedRequest(ctx, http.MethodGet, c.url+RegionsEndpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list regions: %w", err)
+	}
+
+	regions := make([]string, 0)
+	if err := json.Unmarshal(b, &regions); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal list regions response: %w", err)
+	}
+
+	return regions, nil
+}

--- a/nodeshift/provider/client/deployment_test.go
+++ b/nodeshift/provider/client/deployment_test.go
@@ -28,6 +28,12 @@ func newServer(t *testing.T, requestType string) (*httptest.Server, *AsyncAPIDep
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/terraform/deployment/all-countries"):
+			t.Logf("received %s deployment request", requestType)
+
+			b, _ := json.Marshal([]string{"Singapore", "Germany", "Sweden"})
+			//nolint:errcheck
+			w.Write(b)
 		case strings.HasPrefix(r.URL.Path, "/api/terraform/deployment"):
 			t.Logf("received %s deployment request", requestType)
 			response := AsyncAPIDeploymentTask{
@@ -198,4 +204,13 @@ func TestNodeshiftClient_PollDeploymentTask(t *testing.T) {
 	assert.Equal(t, expectedResponse.EndTime, response.EndTime)
 	assert.Equal(t, expectedResponse.Data, response.Data)
 	assert.Equal(t, expectedResponse.ServiceType, response.ServiceType)
+}
+
+func TestNodeshiftClient_ListRegions(t *testing.T) {
+	mockServer, _, client := newServer(t, "listRegions")
+	defer mockServer.Close()
+
+	response, err := client.ListRegions(context.TODO())
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"Singapore", "Germany", "Sweden"}, response)
 }

--- a/nodeshift/provider/client/interfaces.go
+++ b/nodeshift/provider/client/interfaces.go
@@ -31,4 +31,6 @@ type INodeshiftClient interface {
 	GetBucket(ctx context.Context, key string) (*S3BucketConfig, error)
 	UpdateBucket(ctx context.Context, bucket *S3BucketConfig) error
 	DeleteBucket(ctx context.Context, key string) error
+
+	ListRegions(ctx context.Context) ([]string, error)
 }

--- a/nodeshift/provider/provider_test.go
+++ b/nodeshift/provider/provider_test.go
@@ -5,22 +5,18 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/deweb-services/terraform-provider-nodeshift/nodeshift/resource/deployment"
 	"github.com/deweb-services/terraform-provider-nodeshift/nodeshift/resource/gpu"
 	s3terraform "github.com/deweb-services/terraform-provider-nodeshift/nodeshift/resource/s3"
 	"github.com/deweb-services/terraform-provider-nodeshift/nodeshift/resource/vpc"
-
-	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
-
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-
-	"github.com/hashicorp/terraform-plugin-framework/datasource"
-
-	"github.com/hashicorp/terraform-plugin-framework/provider"
 )
 
 func TestNewNodeshiftProvider(t *testing.T) {


### PR DESCRIPTION
## JIRA Issue link

https://dws-corp.atlassian.net/browse/DWS-4693

## Describe your changes
added additional region information message

```
╷
│ Error: Error creating Deployment
│ 
│   with nodeshift_deployment.example,
│   on cpu.tf line 1, in resource "nodeshift_deployment" "example":
│    1: resource "nodeshift_deployment" "example" {
│ 
│ Could not create Deployment, very unexpected error: external API returned an error code: request failed, status code: 400, response body: {"statusCode":400,"message":"The selected region is not
│ supported.","error":"Bad Request"}
╵
╷
│ Error: Invalid region
│ 
│   with nodeshift_deployment.example,
│   on cpu.tf line 1, in resource "nodeshift_deployment" "example":
│    1: resource "nodeshift_deployment" "example" {
│ 
│ Supported regions: []string{"Lithuania", "Netherlands", "United States", "Singapore", "Germany", "Sweden", "Kazakhstan", "Canada", "Turkey", "Brazil", "United Arab Emirates"}
╵

```

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
